### PR TITLE
Add Laravel Sail support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ There are also several debug options which can be adjusted using the following p
 If you are using Laravel Sail and maybe not lokal PHP is installed, you can adjust the following parameters in the git-hooks.php config file:
 
 ```php
-        'use_sail' => env('GITHOOKS_USE_SAIL', false),
+    'use_sail' => env('GITHOOKS_USE_SAIL', false),
 ```
 This will force the local git hooks to use the `sail` command to execute the hooks.
 
@@ -158,8 +158,8 @@ This will force the local git hooks to use the `sail` command to execute the hoo
 By default commands are executed locally, however this behavior can be adjusted for each hook using the parameters `run_in_docker` and `docker_container`:
 
 ```php
-        'run_in_docker' => env('LARAVEL_PINT_RUN_IN_DOCKER', true),
-        'docker_container' => env('LARAVEL_PINT_DOCKER_CONTAINER', 'app'),
+    'run_in_docker' => env('LARAVEL_PINT_RUN_IN_DOCKER', true),
+    'docker_container' => env('LARAVEL_PINT_DOCKER_CONTAINER', 'app'),
 ```
 
 ### Creating Custom Git Hooks

--- a/README.md
+++ b/README.md
@@ -144,6 +144,15 @@ There are also several debug options which can be adjusted using the following p
     */
     'debug_output' => false,
 ```
+### Laravel Sail support
+
+If you are using Laravel Sail and maybe not lokal PHP is installed, you can adjust the following parameters in the git-hooks.php config file:
+
+```php
+        'use_sail' => env('GITHOOKS_USE_SAIL', false),
+```
+This will force the local git hooks to use the `sail` command to execute the hooks.
+
 ### Docker support
 
 By default commands are executed locally, however this behavior can be adjusted for each hook using the parameters `run_in_docker` and `docker_container`:

--- a/config/git-hooks.php
+++ b/config/git-hooks.php
@@ -266,7 +266,7 @@ return [
     | The `artisan_path` configuration is ignored.
     |
     */
-    'use_sail' => false,
+    'use_sail' => env('GITHOOKS_USE_SAIL', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/git-hooks.php
+++ b/config/git-hooks.php
@@ -256,6 +256,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Laravel Sail
+    |--------------------------------------------------------------------------
+    |
+    | If you are using Laravel Sail you may not have local PHP or Composer.
+    |
+    | This configuration option allows you to use local Git but still run Artisan commands with `sail` in front of them.
+    |
+    | The `artisan_path` configuration is ignored.
+    |
+    */
+    'use_sail' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Validate paths
     |--------------------------------------------------------------------------
     |

--- a/config/git-hooks.php
+++ b/config/git-hooks.php
@@ -294,17 +294,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Output errors
-    |--------------------------------------------------------------------------
-    |
-    | This configuration option allows you output any errors encountered
-    | during execution directly for easy debug.
-    |
-    */
-    'output_errors' => env('GITHOOKS_OUTPUT_ERRORS', false),
-
-    /*
-    |--------------------------------------------------------------------------
     | Automatically fix errors
     |--------------------------------------------------------------------------
     |
@@ -336,6 +325,17 @@ return [
     |
     */
     'stop_at_first_analyzer_failure' => env('GITHOOKS_STOP_AT_FIRST_ANALYZER_FAILURE', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Output errors
+    |--------------------------------------------------------------------------
+    |
+    | This configuration option allows you output any errors encountered
+    | during execution directly for easy debug.
+    |
+    */
+    'output_errors' => env('GITHOOKS_OUTPUT_ERRORS', false),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Console/Commands/stubs/hook
+++ b/src/Console/Commands/stubs/hook
@@ -4,4 +4,4 @@ if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then
     exec < /dev/tty
 fi
 
-php {artisanPath} {command} $@ >&2
+{php|sail} {artisanPath} {command} $@ >&2

--- a/src/GitHooks.php
+++ b/src/GitHooks.php
@@ -58,10 +58,24 @@ class GitHooks
 
         $hookPath = $this->getGitHooksDir().'/'.$hookName;
         $hookScript = str_replace(
-            ['{command}', '{artisanPath}'],
-            [$command, config('git-hooks.artisan_path')],
+            '{command}',
+            $command,
             (string) $this->getHookStub()
         );
+
+        if (config('git-hooks.use_sail')) {
+            $hookScript = str_replace(
+                ['{php|sail}', '{artisanPath}'],
+                ['vendor/bin/sail', 'artisan'],
+                $hookScript
+            );
+        } else {
+            $hookScript = str_replace(
+                ['{php|sail}', '{artisanPath}'],
+                ['php', config('git-hooks.artisan_path')],
+                $hookScript
+            );
+        }
 
         file_put_contents($hookPath, $hookScript);
         chmod($hookPath, 0777);


### PR DESCRIPTION
When using Laravel Sail without a local PHP Installation, the command `php {artisanPath} git-hooks:{hookName}` cannot be called. It must be something like `vendor/bin/sail artisan git-hooks:{hookName}`.

This PR adds a further option `use_sail` (`bool`) to be able to switch this behaviour when using Laravel Sail this way.